### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in NpmPackageService

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** The global authentication middleware used `req.originalUrl.includes("/book-rss/feed/")` to bypass authentication for RSS feeds. An attacker could access any protected endpoint by simply appending `?/book-rss/feed/` to the query string, as `originalUrl` includes the query parameters.
 **Learning:** Checking `originalUrl` for allowlisting routes is dangerous because it includes user-controlled query parameters. The allowlist should strictly rely on the normalized path component of the request.
 **Prevention:** Always use `req.path` instead of `req.originalUrl` when determining whether a route should bypass authentication or authorization checks.
+
+## $(date +%Y-%m-%d) - Command Injection Vulnerability
+**Vulnerability:** The \`NpmPackageService\` executed npm commands like \`npm install\` and \`npm uninstall\` using \`child_process.exec\` with concatenated strings for \`packageName\` and \`version\`. This allowed command injection if a malicious user provided a crafted package name.
+**Learning:** Using \`exec\` or \`execAsync\` with string concatenation to invoke system commands is dangerous because the shell evaluates metacharacters.
+**Prevention:** Always use \`child_process.execFile\` or \`child_process.spawn\` with an array of arguments to bypass the shell. Never use string concatenation to form shell commands that include user input.

--- a/backend/src/services/NpmPackageService.ts
+++ b/backend/src/services/NpmPackageService.ts
@@ -4,10 +4,10 @@ import { ApiResponseData } from "../utils/apiResponse";
 import { logger } from "../utils/logger";
 import * as fs from "fs";
 import * as path from "path";
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import { promisify } from "util";
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 @injectable()
 export class NpmPackageService {
@@ -119,8 +119,9 @@ export class NpmPackageService {
       let actualVersion = version;
       if (!actualVersion) {
         try {
-          const { stdout } = await execAsync(`npm view ${packageName} version`, {
+          const { stdout } = await execFileAsync("npm", ["view", packageName, "version"], {
             timeout: 30000,
+            shell: process.platform === "win32", // npm is a batch file on Windows
           });
           actualVersion = stdout.trim();
         } catch (error) {
@@ -140,14 +141,15 @@ export class NpmPackageService {
 
       try {
         // 执行npm安装
-        const installCommand = version
-          ? `npm install ${packageName}@${version} --save`
-          : `npm install ${packageName} --save`;
+        const installArgs = version
+          ? ["install", `${packageName}@${version}`, "--save"]
+          : ["install", packageName, "--save"];
 
-        logger.info(`开始安装npm包: ${installCommand}`);
-        const { stdout, stderr } = await execAsync(installCommand, {
+        logger.info(`开始安装npm包: npm ${installArgs.join(" ")}`);
+        const { stdout, stderr } = await execFileAsync("npm", installArgs, {
           cwd: this.packagesDir,
           timeout: 120000, // 2分钟超时
+          shell: process.platform === "win32",
         });
 
         if (stderr && !stderr.includes("WARN")) {
@@ -220,9 +222,10 @@ export class NpmPackageService {
 
       try {
         // 执行npm卸载
-        await execAsync(`npm uninstall ${packageName}`, {
+        await execFileAsync("npm", ["uninstall", packageName], {
           cwd: this.packagesDir,
           timeout: 60000,
+          shell: process.platform === "win32",
         });
 
         // 删除数据库记录
@@ -274,9 +277,10 @@ export class NpmPackageService {
 
   private async uninstallPackageFiles(packageName: string): Promise<void> {
     try {
-      await execAsync(`npm uninstall ${packageName}`, {
+      await execFileAsync("npm", ["uninstall", packageName], {
         cwd: this.packagesDir,
         timeout: 60000,
+        shell: process.platform === "win32",
       });
     } catch (error) {
       logger.warn(`清理包文件失败: ${packageName}`, error);
@@ -305,7 +309,7 @@ export class NpmPackageService {
 
   private async getDirectorySize(dirPath: string): Promise<number> {
     try {
-      const { stdout } = await execAsync(`du -sb "${dirPath}"`);
+      const { stdout } = await execFileAsync("du", ["-sb", dirPath]);
       return parseInt(stdout.split("\t")[0]);
     } catch (error) {
       logger.warn(`获取目录大小失败: ${dirPath}`, error);


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix command injection in NpmPackageService

🚨 Severity: CRITICAL
💡 Vulnerability: The `NpmPackageService` was using `child_process.exec` to run npm commands with user-controlled input (`packageName`, `version`) concatenated directly into the shell command string.
🎯 Impact: An attacker could perform Remote Code Execution (RCE) via command injection by supplying a crafted package name (e.g., `package; rm -rf /`).
🔧 Fix: Replaced `exec` with `child_process.execFile` and passed arguments as an array, bypassing the shell on Unix systems and preventing metacharacter evaluation.
✅ Verification: Ran `pnpm exec jest` in the backend to ensure tests pass and manually verified the code changes.

---
*PR created automatically by Jules for task [9534686388971594884](https://jules.google.com/task/9534686388971594884) started by @fillpit*