### PR TITLE
⚡ Bolt: Optimize NpmPackage stats query memory footprint

### DIFF
--- a/backend/src/controllers/npmPackage.ts
+++ b/backend/src/controllers/npmPackage.ts
@@ -78,41 +78,7 @@ export class NpmPackageController extends BaseController {
    */
   async getPackageStats(req: Request, res: Response): Promise<void> {
     await this.handleRequest(req, res, async () => {
-      const allPackages = await this.npmPackageService.getAllPackages();
-      if (!allPackages.success) {
-        return allPackages;
-      }
-
-      const packages = allPackages.data || [];
-      const totalPackages = packages.length;
-      const installedPackages = packages.filter((pkg) => pkg.status === "installed").length;
-      const totalSize = packages
-        .filter((pkg) => pkg.status === "installed" && pkg.size)
-        .reduce((sum, pkg) => sum + (pkg.size || 0), 0);
-      const totalUsage = packages.reduce((sum, pkg) => sum + (pkg.usageCount || 0), 0);
-
-      const stats = {
-        totalPackages,
-        installedPackages,
-        totalSize,
-        totalUsage,
-        // 兼容保留原有字段，避免其它调用方受影响
-        total: totalPackages,
-        installed: installedPackages,
-        installing: packages.filter((pkg) => pkg.status === "installing").length,
-        failed: packages.filter((pkg) => pkg.status === "failed").length,
-        mostUsed: packages
-          .filter((pkg) => pkg.status === "installed")
-          .sort((a, b) => (b.usageCount || 0) - (a.usageCount || 0))
-          .slice(0, 5)
-          .map((pkg) => ({ name: pkg.name, usageCount: pkg.usageCount, lastUsed: pkg.lastUsed })),
-      };
-
-      return {
-        success: true,
-        data: stats,
-        message: "获取统计信息成功",
-      };
+      return await this.npmPackageService.getStats();
     });
   }
 }

--- a/backend/src/services/NpmPackageService.ts
+++ b/backend/src/services/NpmPackageService.ts
@@ -79,6 +79,57 @@ export class NpmPackageService {
     }
   }
 
+  async getStats(): Promise<ApiResponseData<any>> {
+    try {
+      // ⚡ Bolt: Fetch only necessary columns to prevent memory bloat.
+      // This optimization skips heavy text/BLOB columns (like dependencies, description)
+      // during list processing, significantly reducing DB memory usage and transfer latency.
+      const packages = await NpmPackage.findAll({
+        attributes: ["status", "size", "usageCount", "name", "lastUsed"],
+      });
+
+      const totalPackages = packages.length;
+      const installedPackages = packages.filter((pkg) => pkg.status === "installed").length;
+      const totalSize = packages
+        .filter((pkg) => pkg.status === "installed" && pkg.size)
+        .reduce((sum, pkg) => sum + (pkg.size || 0), 0);
+      const totalUsage = packages.reduce((sum, pkg) => sum + (pkg.usageCount || 0), 0);
+
+      const stats = {
+        totalPackages,
+        installedPackages,
+        totalSize,
+        totalUsage,
+        total: totalPackages,
+        installed: installedPackages,
+        installing: packages.filter((pkg) => pkg.status === "installing").length,
+        failed: packages.filter((pkg) => pkg.status === "failed").length,
+        mostUsed: packages
+          .filter((pkg) => pkg.status === "installed")
+          .sort((a, b) => (b.usageCount || 0) - (a.usageCount || 0))
+          .slice(0, 5)
+          .map((pkg) => ({
+            name: pkg.name,
+            usageCount: pkg.usageCount,
+            lastUsed: pkg.lastUsed,
+          })),
+      };
+
+      return {
+        success: true,
+        data: stats,
+        message: "获取统计信息成功",
+      };
+    } catch (error) {
+      logger.error("获取npm包统计信息失败:", error);
+      return {
+        success: false,
+        data: undefined,
+        message: "获取统计信息失败",
+      };
+    }
+  }
+
   async getInstalledPackages(): Promise<ApiResponseData<NpmPackageAttributes[]>> {
     try {
       const packages = await NpmPackage.findAll({


### PR DESCRIPTION
I've implemented a performance optimization for fetching NPM package statistics. 

Previously, `NpmPackageController.getPackageStats` was calling `npmPackageService.getAllPackages()`, which retrieves all fields from the database, including potentially large TEXT columns like `dependencies` and `description`. 

By creating a dedicated `getStats` method in `NpmPackageService`, we now use `attributes: ["status", "size", "usageCount", "name", "lastUsed"]` to fetch only the data necessary for the calculation. This significantly reduces the memory footprint on the Node.js server and database transfer latency, especially when the number of stored packages grows.

Relevant tests passed successfully and changes were scoped correctly.

---
*PR created automatically by Jules for task [7836658179448373370](https://jules.google.com/task/7836658179448373370) started by @fillpit*