### PR TITLE
⚡ Bolt: exclude `lastContent` caching from WebsiteRss in backup exports

### DIFF
--- a/backend/src/controllers/backup.ts
+++ b/backend/src/controllers/backup.ts
@@ -198,10 +198,13 @@ export class BackupController {
     });
 
     // 获取网站RSS订阅
+    // ⚡ Bolt: 优化性能，排除 lastContent 字段。
+    // 该字段包含了RSS抓取的完整缓存内容，数据量可能非常大（数MB甚至数十MB）。
+    // 在导出备份时排除该字段可以显著减少内存占用，加快序列化速度，并大幅减小备份文件体积。
     const websiteRss = await sequelize.models.WebsiteRss.findAll({
       where: { userId },
       attributes: {
-        exclude: ["id", "userId", "createdAt", "updatedAt"],
+        exclude: ["id", "userId", "createdAt", "updatedAt", "lastContent"],
       },
     });
 
@@ -238,10 +241,13 @@ export class BackupController {
     const sequelize = this.databaseService.getSequelize();
 
     // 获取网站RSS订阅（排除敏感字段）
+    // ⚡ Bolt: 优化性能，排除 lastContent 字段。
+    // 分享配置时不需要包含RSS缓存数据。排除它可以避免生成过大的分享文件，
+    // 降低内存消耗，提高响应速度。
     const websiteRss = await sequelize.models.WebsiteRss.findAll({
       where: { userId },
       attributes: {
-        exclude: ["id", "userId", "authCredentialId", "createdAt", "updatedAt"],
+        exclude: ["id", "userId", "authCredentialId", "createdAt", "updatedAt", "lastContent"],
       },
     });
 


### PR DESCRIPTION
💡 What: Excluded the `lastContent` field from `WebsiteRss.findAll` queries during backup and share data exports in `backend/src/controllers/backup.ts`.
🎯 Why: `lastContent` contains the full JSON string of cached RSS feed data, which can grow very large (several MBs per user). Pulling this into memory to serialize as JSON for simple configuration backups/sharing is unnecessary and causes memory bloat.
📊 Impact: Significantly reduces memory footprint during backup generation and creates much smaller export files.
🔬 Measurement: Verify by executing a backup on an account with many populated RSS feeds; the resulting JSON size will drop significantly and the API endpoint will respond faster.

---
*PR created automatically by Jules for task [9541165131124392057](https://jules.google.com/task/9541165131124392057) started by @fillpit*