### PR TITLE
🎨 Palette: [UX improvement] Add confirmation dialog for deleting auth credentials

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -10,3 +10,7 @@
 **Learning:** Icon-only buttons are a common pattern for "clean" UI, but they are invisible to screen readers without explicit `aria-label` or `aria-labelledby`. Tooltips (`el-tooltip`) are great for mouse users but do not always bridge the gap for assistive technology.
 **Action:** Always verify icon-only buttons have an `aria-label` describing the action, not just the icon name.
 
+
+## 2026-04-08 - Destructive Action Confirmation
+**Learning:** Destructive actions without confirmation dialogues (like deleting an auth credential) can lead to accidental data loss. Using `el-popconfirm` provides a lightweight, inline confirmation without the heavy interruption of a modal dialog, offering a better user experience for table actions.
+**Action:** Always wrap delete actions in list/table views with an `el-popconfirm` or similar confirmation mechanism to prevent accidental deletions.

--- a/frontend/src/views/AuthCredentialManagement.vue
+++ b/frontend/src/views/AuthCredentialManagement.vue
@@ -35,13 +35,21 @@
               @click="edit(scope.row)"
               >编辑</el-button
             >
-            <el-button
-              size="small"
-              type="danger"
-              :aria-label="'删除授权: ' + scope.row.name"
-              @click="remove(scope.row.id)"
-              >删除</el-button
+            <el-popconfirm
+              title="确定要删除此授权信息吗？"
+              confirm-button-text="确定"
+              cancel-button-text="取消"
+              @confirm="remove(scope.row.id)"
             >
+              <template #reference>
+                <el-button
+                  size="small"
+                  type="danger"
+                  :aria-label="'删除授权: ' + scope.row.name"
+                  >删除</el-button
+                >
+              </template>
+            </el-popconfirm>
           </template>
         </el-table-column>
       </el-table>


### PR DESCRIPTION
🎨 Palette: 添加删除授权信息确认框

💡 What: 在授权信息管理页面的删除按钮外层包裹了 `el-popconfirm` 组件。
🎯 Why: 原本的删除按钮点击后会立即执行删除操作，没有确认步骤，容易导致用户误删授权信息，造成数据丢失。添加轻量级的气泡确认框可以在不打断用户工作流的情况下提供安全保障。
📸 Before/After: （请参考前端验证截图）
♿ Accessibility: 保持了原有的键盘可访问性和无障碍标签。

---
*PR created automatically by Jules for task [10676630546842947372](https://jules.google.com/task/10676630546842947372) started by @fillpit*